### PR TITLE
enchilada: Give light sensor some time to warm up

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -83,4 +83,9 @@
 
     <!-- Period of time in which to consider light samples in milliseconds. -->
     <integer name="config_autoBrightnessAmbientLightHorizon">10000</integer>
+
+    <!-- Amount of time it takes for the light sensor to warm up in milliseconds.
+         For this time after the screen turns on, the Power Manager
+         will not debounce light sensor readings -->
+    <integer name="config_lightSensorWarmupTime">200</integer>
 </resources>


### PR DESCRIPTION
When being in dark environments, turning screen off, then moving to
bright environments and turning screen on, sometimes it happens that the
light sensor emits an initial light sample of 1 lux, which causes the
automatic brightness controller to ramp down the brightness even though
the ambient brightness is high. Avoid the controller using those samples
by giving the light sensor some time to warm up.

Change-Id: I81dcb41a25ff0c9f0cf3265da7054ac7ebcbcc34